### PR TITLE
Fix: Improve error handling in README update workflow

### DIFF
--- a/scrapers/agent_scraper.py
+++ b/scrapers/agent_scraper.py
@@ -18,5 +18,4 @@ def fetch_agent_benchmarks():
             })
         return results
     except Exception as e:
-        print(f"Error fetching agent benchmarks: {e}")
-        return []
+        raise

--- a/scrapers/ide_scraper.py
+++ b/scrapers/ide_scraper.py
@@ -27,5 +27,4 @@ def fetch_ide_benchmarks():
                 "Cost ($/1k tokens)": "No recent build info"
             }]
     except Exception as e:
-        print(f"Error fetching IDE benchmarks: {e}")
-        return []
+        raise

--- a/scrapers/llm_scraper.py
+++ b/scrapers/llm_scraper.py
@@ -17,5 +17,4 @@ def fetch_llm_benchmarks():
             })
         return results
     except Exception as e:
-        print(f"Error fetching LLM benchmarks: {e}")
-        return []
+        raise

--- a/update_readme.py
+++ b/update_readme.py
@@ -1,5 +1,6 @@
 import os
 import json
+import sys # Import sys
 import requests
 from datetime import datetime
 from utils.formatter import format_markdown_table
@@ -14,22 +15,22 @@ if not os.path.exists('data'):
     os.makedirs('data')
 
 def main():
-    # Fetch data
-    llm_data, ide_data, agent_data = [], [], []
+    llm_data, ide_data, agent_data = [], [], [] # Initialize here
     try:
+        # Fetch data
+        print("Fetching LLM benchmarks...")
         llm_data = fetch_llm_benchmarks()
-    except Exception as e:
-        print(f"Error fetching LLM benchmarks: {e}")
-    try:
+        print("Fetching IDE benchmarks...")
         ide_data = fetch_ide_benchmarks()
-    except Exception as e:
-        print(f"Error fetching IDE benchmarks: {e}")
-    try:
+        print("Fetching Agent benchmarks...")
         agent_data = fetch_agent_benchmarks()
+        print("All data fetched successfully.")
     except Exception as e:
-        print(f"Error fetching agent benchmarks: {e}")
+        print(f"ERROR: Failed to fetch benchmark data. Details: {e}")
+        sys.exit(1)
 
     # Combine
+    print("Combining data...")
     all_data = llm_data + ide_data + agent_data
 
     # Save


### PR DESCRIPTION
This commit introduces several changes to enhance the robustness and error reporting of the automated README benchmark update workflow:

1.  **Scraper Error Propagation**:
    *   Modified `scrapers/agent_scraper.py`, `scrapers/ide_scraper.py`, and `scrapers/llm_scraper.py` to re-raise exceptions encountered during data fetching. Previously, these errors were printed but suppressed, potentially leading to silent failures or incomplete README updates.

2.  **Main Script Failure on Error**:
    *   Updated `update_readme.py` to catch any exceptions raised by the scraper functions.
    *   If an error occurs during data fetching, the script now prints a detailed error message and exits with a non-zero status code (`sys.exit(1)`). This will ensure that the corresponding GitHub Actions workflow step is marked as failed, making issues visible.
    *   Added more detailed print logging for better traceability of the script's execution.

3.  **URL Status Investigation**:
    *   `llm_scraper.py`: The target URL for Hugging Face's `open-llm-leaderboard/results` dataset is correct. However, the dataset itself is currently experiencing a `DatasetGenerationError` on the Hugging Face platform, causing the API to return a 422 error. The improved error handling will now correctly report this.
    *   `agent_scraper.py`: The target URL for `swe-bench/swe-bench.github.io`'s `leaderboards.json` is consistently returning a 404 Not Found error. Investigation did not locate a new public URL. The workflow will now fail clearly, indicating this data source is unavailable.

These changes ensure that workflow runs provide clear signals when benchmark data cannot be fully updated, addressing the issue of identifying errors in the `update-readme.yml` workflow.